### PR TITLE
Add dummy discord bans notification

### DIFF
--- a/Content.Server/Administration/Managers/BanManager.cs
+++ b/Content.Server/Administration/Managers/BanManager.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Content.Server.Chat.Managers;
 using Content.Server.Database;
 using Content.Server.GameTicking;
+using Content.Shared._CP.CCVars;
 using Content.Shared.CCVar;
 using Content.Shared.Database;
 using Content.Shared.Players;
@@ -62,6 +63,11 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
 
         _userDbData.AddOnLoadPlayer(CachePlayerData);
         _userDbData.AddOnPlayerDisconnect(ClearPlayerData);
+
+        _cfg.OnValueChanged(CPCCVars.DiscordBanNotificationWebhook, v => _banWebhookUrl = v, true);
+        _cfg.OnValueChanged(CPCCVars.DiscordBanNotificationName, v => _banNotificationName = v, true);
+        _cfg.OnValueChanged(CPCCVars.DiscordBanNotificationAvatarUrl, v => _banAvatarUrl = v, true);
+        _cfg.OnValueChanged(CPCCVars.DiscordBanNotificationFooterIconUrl, v => _banFooterIconUrl = v, true);
     }
 
     private async Task CachePlayerData(ICommonSession player, CancellationToken cancel)
@@ -175,6 +181,8 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
         var hwidString = hwid?.ToString() ?? "null";
         var expiresString = expires == null ? Loc.GetString("server-ban-string-never") : $"{expires}";
 
+        _ = SendServerBan(targetName, adminName, reason, expires, roundId);
+
         var key = _cfg.GetCVar(CCVars.AdminShowPIIOnBan) ? "server-ban-string" : "server-ban-string-no-pii";
 
         var logMessage = Loc.GetString(
@@ -233,7 +241,7 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
     #region Job Bans
     // If you are trying to remove timeOfBan, please don't. It's there because the note system groups role bans by time, reason and banning admin.
     // Removing it will clutter the note list. Please also make sure that department bans are applied to roles with the same DateTimeOffset.
-    public async void CreateRoleBan(NetUserId? target, string? targetUsername, NetUserId? banningAdmin, (IPAddress, int)? addressRange, ImmutableTypedHwid? hwid, string role, uint? minutes, NoteSeverity severity, string reason, DateTimeOffset timeOfBan)
+    public async void CreateRoleBan(NetUserId? target, string? targetUsername, NetUserId? banningAdmin, (IPAddress, int)? addressRange, ImmutableTypedHwid? hwid, string role, uint? minutes, NoteSeverity severity, string reason, DateTimeOffset timeOfBan, bool sendNotification)
     {
         if (!_prototypeManager.TryIndex(role, out JobPrototype? _))
         {
@@ -270,6 +278,16 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
         {
             _chat.SendAdminAlert(Loc.GetString("cmd-roleban-existing", ("target", targetUsername ?? "null"), ("role", role)));
             return;
+        }
+
+        var adminName = banningAdmin == null
+            ? Loc.GetString("system-user")
+            : (await _db.GetPlayerRecordByUserId(banningAdmin.Value))?.LastSeenUserName ?? Loc.GetString("system-user");
+        var targetName = target is null ? "null" : $"{targetUsername} ({target})";
+
+        if (sendNotification)
+        {
+            _ = SendJobBan(targetName, adminName, role, reason, expires ?? DateTimeOffset.Now, roundId);
         }
 
         var length = expires == null ? Loc.GetString("cmd-roleban-inf") : Loc.GetString("cmd-roleban-until", ("expires", expires));

--- a/Content.Server/Administration/Managers/IBanManager.cs
+++ b/Content.Server/Administration/Managers/IBanManager.cs
@@ -37,7 +37,8 @@ public interface IBanManager
     /// <param name="reason">Reason for the ban</param>
     /// <param name="minutes">Number of minutes to ban for. 0 and null mean permanent</param>
     /// <param name="timeOfBan">Time when the ban was applied, used for grouping role bans</param>
-    public void CreateRoleBan(NetUserId? target, string? targetUsername, NetUserId? banningAdmin, (IPAddress, int)? addressRange, ImmutableTypedHwid? hwid, string role, uint? minutes, NoteSeverity severity, string reason, DateTimeOffset timeOfBan);
+    /// <param name="sendDiscordNotification">Sends discord ban notification.</param>
+    public void CreateRoleBan(NetUserId? target, string? targetUsername, NetUserId? banningAdmin, (IPAddress, int)? addressRange, ImmutableTypedHwid? hwid, string role, uint? minutes, NoteSeverity severity, string reason, DateTimeOffset timeOfBan, bool sendDiscordNotification=true);
 
     /// <summary>
     /// Pardons a role ban for the specified target, username or GUID
@@ -52,4 +53,18 @@ public interface IBanManager
     /// </summary>
     /// <param name="pSession">Player's session</param>
     public void SendRoleBans(ICommonSession pSession);
+
+    public Task SendJobBansRoles(string bannedUser,
+        string administrator,
+        string[] roles,
+        string reason,
+        DateTimeOffset? duration,
+        int? round);
+
+    public Task SendJobBanDepartment(string bannedUser,
+        string administrator,
+        string departments,
+        string reason,
+        DateTimeOffset? duration,
+        int? round);
 }

--- a/Content.Server/_CP/Administration/Managers/BanManager.Discord.cs
+++ b/Content.Server/_CP/Administration/Managers/BanManager.Discord.cs
@@ -1,0 +1,180 @@
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Content.Server.Discord;
+
+namespace Content.Server.Administration.Managers;
+
+public sealed partial class BanManager
+{
+    private readonly HttpClient _httpClient = new();
+
+    private string _banWebhookUrl = string.Empty;
+    private string _banNotificationName = string.Empty;
+    private string _banAvatarUrl = string.Empty;
+    private string _banFooterIconUrl = string.Empty;
+
+    private async Task SendServerBan(string bannedUser, string administrator, string reason, DateTimeOffset? duration, int? round)
+    {
+        var expiration = duration != null
+            ? Loc.GetString("ban-notification-time-expires", ("totalSeconds", duration.Value.ToUnixTimeSeconds()))
+            : Loc.GetString("ban-notification-never-expires");
+
+        bannedUser = GetOnlyNickname(bannedUser);
+        var embed = new WebhookEmbed
+        {
+            Description = Loc.GetString(
+                "discord-webhook-server-ban-notification",
+                ("nickname", bannedUser),
+                ("administrator", administrator),
+                ("expiration", expiration),
+                ("reason", reason)
+            ),
+            Color = 0XFF0000,
+            Footer = new WebhookEmbedFooter
+            {
+                Text = Loc.GetString("discord-webhook-server-ban-notification-footer", ("round", round ?? 0)),
+                IconUrl = _banFooterIconUrl,
+            },
+        };
+
+        await SendDiscordEmbed([embed], _banNotificationName, _banAvatarUrl);
+    }
+
+    private async Task SendJobBan(string bannedUser, string administrator, string job, string reason, DateTimeOffset? duration, int? round)
+    {
+        var expiration = duration != null
+            ? Loc.GetString("ban-notification-time-expires", ("totalSeconds", duration.Value.ToUnixTimeSeconds()))
+            : Loc.GetString("ban-notification-never-expires");
+
+        bannedUser = GetOnlyNickname(bannedUser);
+        var embed = new WebhookEmbed
+        {
+            Description = Loc.GetString(
+                "discord-webhook-job-ban-notification",
+                ("nickname", bannedUser),
+                ("administrator", administrator),
+                ("expiration", expiration),
+                ("job", job),
+                ("reason", reason)
+            ),
+            Color = 0XFF0000,
+            Footer = new WebhookEmbedFooter
+            {
+                Text = Loc.GetString("discord-webhook-server-ban-notification-footer", ("round", round ?? 0)),
+                IconUrl = _banFooterIconUrl,
+            },
+        };
+
+        await SendDiscordEmbed([embed], _banNotificationName, _banAvatarUrl);
+    }
+
+    public async Task SendJobBansRoles(string bannedUser, string administrator, string[] roles, string reason, DateTimeOffset? duration, int? round)
+    {
+        var expiration = duration != null
+            ? Loc.GetString("ban-notification-time-expires", ("totalSeconds", duration.Value.ToUnixTimeSeconds()))
+            : Loc.GetString("ban-notification-never-expires");
+
+        var list = new StringBuilder();
+
+        foreach (var role in roles)
+        {
+            list.Append(Loc.GetString("discord-webhook-job-ban-notification-entry", ("job", role)));
+            list.Append('\n');
+        }
+
+        bannedUser = GetOnlyNickname(bannedUser);
+        var embed = new WebhookEmbed
+        {
+            Description = Loc.GetString(
+                "discord-webhook-job-roles-ban-notification",
+                ("nickname", bannedUser),
+                ("administrator", administrator),
+                ("expiration", expiration),
+                ("list", list),
+                ("reason", reason)
+            ),
+            Color = 0XFF0000,
+            Footer = new WebhookEmbedFooter
+            {
+                Text = Loc.GetString("discord-webhook-server-ban-notification-footer", ("round", round ?? 0)),
+                IconUrl = _banFooterIconUrl,
+            },
+        };
+
+        await SendDiscordEmbed([embed], _banNotificationName, _banAvatarUrl);
+    }
+
+    public async Task SendJobBanDepartment(string bannedUser, string administrator, string department, string reason, DateTimeOffset? duration, int? round)
+    {
+        var expiration = duration != null
+            ? Loc.GetString("ban-notification-time-expires", ("totalSeconds", duration.Value.ToUnixTimeSeconds()))
+            : Loc.GetString("ban-notification-never-expires");
+
+        bannedUser = GetOnlyNickname(bannedUser);
+        var embed = new WebhookEmbed
+        {
+            Description = Loc.GetString(
+                "discord-webhook-job-departments-ban-notification",
+                ("nickname", bannedUser),
+                ("administrator", administrator),
+                ("expiration", expiration),
+                ("department", department),
+                ("reason", reason)
+            ),
+            Color = 0XFF0000,
+            Footer = new WebhookEmbedFooter
+            {
+                Text = Loc.GetString("discord-webhook-server-ban-notification-footer", ("round", round ?? 0)),
+                IconUrl = _banFooterIconUrl,
+            },
+        };
+
+        await SendDiscordEmbed([embed], _banNotificationName, _banAvatarUrl);
+    }
+
+    private async Task SendDiscordEmbed(List<WebhookEmbed> embeds, string name, string? avatarUrl = null)
+    {
+        if (_banWebhookUrl == string.Empty)
+        {
+            _sawmill.Info("Ban Webhook URL is empty, ignoring sending discord notification.");
+            return;
+        }
+
+        var payload = new WebhookPayload()
+        {
+            Embeds = embeds,
+            Username = name,
+            AvatarUrl = avatarUrl,
+        };
+
+        var request = await _httpClient.PostAsync(
+            $"{_banWebhookUrl}?wait=true",
+            new StringContent(
+                JsonSerializer.Serialize(payload),
+                Encoding.UTF8,
+                "application/json"
+            ));
+
+        var content = await request.Content.ReadAsStringAsync();
+        if (!request.IsSuccessStatusCode)
+        {
+            _sawmill.Log(LogLevel.Error, $"Discord returned bad status code when posting message (perhaps the message is too long?): {request.StatusCode}\nResponse: {content}");
+            return;
+        }
+
+        var id = JsonNode.Parse(content)?["id"];
+        if (id == null)
+        {
+            _sawmill.Log(LogLevel.Error, $"Could not find id in json-content returned from discord webhook: {content}");
+        }
+    }
+
+    private string GetOnlyNickname(string nickname)
+    {
+        var index = nickname.LastIndexOf(' ');
+        return index == -1 ? nickname : nickname[..index];
+    }
+}

--- a/Content.Shared/_CP/CCVars/CPCCVars.Discord.cs
+++ b/Content.Shared/_CP/CCVars/CPCCVars.Discord.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._CP.CCVars;
+
+// ReSharper disable once InconsistentNaming
+public sealed partial class CPCCVars
+{
+    public static readonly CVarDef<string> DiscordBanNotificationWebhook =
+        CVarDef.Create("discord.ban_notification_webhook", string.Empty, CVar.SERVERONLY | CVar.CONFIDENTIAL);
+
+    public static readonly CVarDef<string> DiscordBanNotificationName =
+        CVarDef.Create("discord.ban_notification_name", "Jandarma Office", CVar.SERVERONLY);
+
+    public static readonly CVarDef<string> DiscordBanNotificationAvatarUrl =
+        CVarDef.Create("discord.ban_notification_icon_url", string.Empty, CVar.SERVERONLY);
+
+    public static readonly CVarDef<string> DiscordBanNotificationFooterIconUrl =
+        CVarDef.Create("discord.ban_notification_footer_icon_url", string.Empty, CVar.SERVERONLY);
+}

--- a/Content.Shared/_CP/CCVars/CPCCVars.cs
+++ b/Content.Shared/_CP/CCVars/CPCCVars.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._CP.CCVars;
+
+/// <summary>
+/// CP CCVars.
+/// </summary>
+[CVarDefs]
+// ReSharper disable once InconsistentNaming
+public sealed partial class CPCCVars
+{
+}

--- a/Resources/Locale/en-US/_cp/bans/webhook-data.ftl
+++ b/Resources/Locale/en-US/_cp/bans/webhook-data.ftl
@@ -1,0 +1,41 @@
+discord-webhook-server-ban-notification =
+    ### Server Ban
+    > *Nickname*: { $nickname }
+    > *Administrator*: { $administrator }
+    > *Expiration*: { $expiration }
+    > *Reason*: { $reason }
+
+
+discord-webhook-job-ban-notification =
+    ### Job Ban
+    > *Nickname*: { $nickname }
+    > *Administrator*: { $administrator }
+    > *Expiration*: { $expiration }
+    > *Job*: { $job }
+    > *Reason*: { $reason }
+
+
+discord-webhook-job-roles-ban-notification =
+    ### Job Ban
+    > *Nickname*: { $nickname }
+    > *Administrator*: { $administrator }
+    > *Expiration*: { $expiration }
+    > *Reason*: { $reason }
+    > *Jobs*:
+    { $list }
+
+
+discord-webhook-job-departments-ban-notification =
+    ### Job Ban
+    > *Nickname*: { $nickname }
+    > *Administrator*: { $administrator }
+    > *Expiration*: { $expiration }
+    > *Department*: { $department }
+    > *Reason*: { $reason }
+
+discord-webhook-job-ban-notification-entry = - { $job }
+
+discord-webhook-server-ban-notification-footer = Round { $round }
+
+ban-notification-time-expires =  <t:{ $totalSeconds }:F>
+ban-notification-never-expires = Never expires


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds discord notifications for bans.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Added Discord bans notifications.